### PR TITLE
feat: exercise compose drag and drop

### DIFF
--- a/src/components/compose/Item.tsx
+++ b/src/components/compose/Item.tsx
@@ -1,12 +1,15 @@
 import ExerciseCard from "@/components/compose/ExerciseCard";
 import { useSelectExerciseQuery } from "@/generated/graphql.tsx";
-import { composeAtom } from "@/util/atoms";
 import { composeStore, ExerciseView } from "@/util/composeStore";
 import { COMPOSE_HEIGHT } from "@/util/const";
-import type { UniqueIdentifier } from "@dnd-kit/core";
+import {
+  type UniqueIdentifier,
+  useDraggable,
+  useDroppable,
+} from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
 import { Box, Skeleton } from "@mui/material";
 import { motion } from "framer-motion";
-import { useAtom } from "jotai";
 import { FC, useCallback, useContext, useMemo, useRef } from "react";
 import { useToggle } from "react-use";
 import { ContainerContext } from "./Container";
@@ -31,53 +34,37 @@ export const Item: FC<{
   const selectedOrder = composeStore((state) => state.selectedOrder);
   const exerciseView = composeStore((state) => state.exerciseView);
   const view = composeStore((state) => state.view);
-  const [items, setItems] = useAtom(composeAtom);
 
   const height = view === "all" ? COMPOSE_HEIGHT.SHORT : COMPOSE_HEIGHT.TALL;
   const isSelected =
     containerId === selectedContainer && order === selectedOrder;
 
+  const dndId = `${containerId}:${order}`;
+  const {
+    setNodeRef: setDragRef,
+    attributes,
+    listeners,
+    transform,
+    isDragging,
+  } = useDraggable({
+    id: dndId,
+    data: { containerId, order },
+    disabled: !id || exerciseView !== ExerciseView.CARD,
+  });
+  const { setNodeRef: setDropRef, isOver } = useDroppable({
+    id: dndId,
+    data: { containerId, order },
+  });
+
   const onClick = useCallback(() => {
     if (exerciseView !== ExerciseView.CARD) return;
     if (!containerId) return;
-
     if (isSelected) {
-      // same as selected
       clear();
-    } else if (
-      selectedContainer &&
-      selectedOrder !== null &&
-      items[selectedContainer][selectedOrder].id
-    ) {
-      // something is selected
-      setItems((draft) => {
-        const aId = draft[selectedContainer][selectedOrder].id;
-        const aCardId = draft[selectedContainer][selectedOrder].cardId;
-        const bId = draft[containerId][order].id;
-        const bCardId = draft[containerId][order].cardId;
-        draft[containerId][order] = { id: aId, cardId: aCardId };
-        draft[selectedContainer][selectedOrder] = {
-          id: bId,
-          cardId: bCardId,
-        };
-      });
-      setSelected(containerId, order);
     } else {
-      // nothing is selected
       setSelected(containerId, order);
     }
-  }, [
-    clear,
-    containerId,
-    exerciseView,
-    isSelected,
-    items,
-    order,
-    selectedContainer,
-    selectedOrder,
-    setItems,
-    setSelected,
-  ]);
+  }, [clear, containerId, exerciseView, isSelected, order, setSelected]);
 
   const memoizedCard = useMemo(
     () => (
@@ -112,22 +99,49 @@ export const Item: FC<{
   );
 
   const [open, toggle] = useToggle(false);
-  const anchorRef = useRef<HTMLDivElement>(null);
+  const anchorRef = useRef<HTMLDivElement | null>(null);
+
+  const setRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      anchorRef.current = node;
+      setDragRef(node);
+      setDropRef(node);
+    },
+    [setDragRef, setDropRef],
+  );
 
   return (
     <>
       <Box
         data-card-id={cardId}
-        ref={anchorRef}
+        ref={setRef}
+        {...attributes}
+        {...listeners}
         width={"100%"}
         height={height}
         minHeight={COMPOSE_HEIGHT.SHORT}
+        style={{
+          transform: CSS.Translate.toString(transform),
+          opacity: isDragging ? 0.4 : 1,
+          zIndex: isDragging ? 1000 : undefined,
+          touchAction: "none",
+        }}
         sx={{
-          transition: "0.2s",
+          transition: "outline 0.2s, background-color 0.2s",
           borderRadius: 1,
           border: "1px solid #e0e0e0",
-          outline: isSelected ? "2px solid highlight" : "2px solid transparent",
-          cursor: exerciseView === ExerciseView.CARD ? "pointer" : "default",
+          outline: isSelected
+            ? "2px solid highlight"
+            : isOver && !isDragging
+              ? "2px dashed #1976d2"
+              : "2px solid transparent",
+          cursor: !id
+            ? "default"
+            : exerciseView === ExerciseView.CARD
+              ? isDragging
+                ? "grabbing"
+                : "grab"
+              : "default",
         }}
         onClick={onClick}
         onContextMenu={(e) => {

--- a/src/components/compose/ItemMenu.tsx
+++ b/src/components/compose/ItemMenu.tsx
@@ -15,7 +15,7 @@ import { FC, RefObject, useContext } from "react";
 import { ContainerContext } from "./Container";
 
 export const ItemMenu: FC<{
-  anchorRef: RefObject<HTMLDivElement>;
+  anchorRef: RefObject<HTMLDivElement | null>;
   id: UniqueIdentifier | null;
   order: number;
   open: boolean;

--- a/src/pages/exerciseSheets/Compose.tsx
+++ b/src/pages/exerciseSheets/Compose.tsx
@@ -1,11 +1,20 @@
-import { FC, Fragment, memo, useMemo } from "react";
+import { FC, Fragment, memo, useCallback, useMemo } from "react";
 
 import { useComposeKeys } from "@/components/compose/useComposeKeys";
+import { composeAtom } from "@/util/atoms";
 import { composeStore, ComposeView } from "@/util/composeStore";
 import { ageGroupTexts, levels } from "@/util/const";
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
 import { ChevronLeft } from "@mui/icons-material";
 import { Button, Grid2, Stack, Typography } from "@mui/material";
 import { LayoutGroup } from "framer-motion";
+import { useSetAtom } from "jotai";
 import { keys, times, values } from "lodash";
 import Container from "../../components/compose/Container";
 
@@ -25,83 +34,106 @@ const ComposeComponent: FC<{ onViewChange: (view: ComposeView) => void }> = ({
 
   useComposeKeys();
 
+  const setItems = useSetAtom(composeAtom);
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  );
+
+  const onDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+      const a = active.data.current as { containerId: string; order: number };
+      const b = over.data.current as { containerId: string; order: number };
+      if (!a || !b) return;
+      setItems((draft) => {
+        const tmp = draft[a.containerId][a.order];
+        draft[a.containerId][a.order] = draft[b.containerId][b.order];
+        draft[b.containerId][b.order] = tmp;
+      });
+    },
+    [setItems],
+  );
+
   return (
-    <LayoutGroup>
-      <Stack direction={"row"} p={2} gap={4} alignItems={"start"}>
-        <Grid2 container columns={5} size={"grow"} spacing={1}>
-          {view === "all" ? (
-            <>
-              {times(5).map((i) => (
-                <Grid2 key={i} size={1}>
-                  <Button
-                    sx={{
-                      width: "100%",
-                    }}
-                    onClick={() => {
-                      onViewChange(keys(ageGroupTexts)[i] as ComposeView);
-                    }}
-                  >
-                    {values(ageGroupTexts)[i]}
-                  </Button>
-                </Grid2>
-              ))}
-            </>
-          ) : (
-            <>
-              <Button
-                startIcon={<ChevronLeft />}
-                onClick={() => {
-                  onViewChange("all");
-                }}
-                sx={{ position: "absolute" }}
-              >
-                Mind
-              </Button>
-              <Typography
-                fontSize={14}
-                fontWeight={"500"}
-                height={"36px"}
-                lineHeight={"36px"}
-                width={"100%"}
-                textAlign={"center"}
-              >
-                {ageGroupTexts[view]}
-              </Typography>
-            </>
-          )}
-          {containerKeys.map((key, i) => {
-            return (
-              <Fragment key={key}>
-                {i % 5 === 0 && (
-                  <Grid2 size={5}>
-                    <Typography
-                      fontSize={14}
-                      paddingLeft={1}
-                      fontWeight={"500"}
+    <DndContext sensors={sensors} onDragEnd={onDragEnd}>
+      <LayoutGroup>
+        <Stack direction={"row"} p={2} gap={4} alignItems={"start"}>
+          <Grid2 container columns={5} size={"grow"} spacing={1}>
+            {view === "all" ? (
+              <>
+                {times(5).map((i) => (
+                  <Grid2 key={i} size={1}>
+                    <Button
+                      sx={{
+                        width: "100%",
+                      }}
+                      onClick={() => {
+                        onViewChange(keys(ageGroupTexts)[i] as ComposeView);
+                      }}
                     >
-                      {levels[i / 5].name}
-                    </Typography>
+                      {values(ageGroupTexts)[i]}
+                    </Button>
                   </Grid2>
-                )}
-                {view === "all" ? (
-                  <Grid2 size={1} component={"div"}>
-                    <Container id={key} />
-                  </Grid2>
-                ) : (
-                  <>
-                    {key.split("-")[0] === view && (
-                      <Grid2 size={5} component={"div"}>
-                        <Container id={key} />
-                      </Grid2>
-                    )}
-                  </>
-                )}
-              </Fragment>
-            );
-          })}
-        </Grid2>
-      </Stack>
-    </LayoutGroup>
+                ))}
+              </>
+            ) : (
+              <>
+                <Button
+                  startIcon={<ChevronLeft />}
+                  onClick={() => {
+                    onViewChange("all");
+                  }}
+                  sx={{ position: "absolute" }}
+                >
+                  Mind
+                </Button>
+                <Typography
+                  fontSize={14}
+                  fontWeight={"500"}
+                  height={"36px"}
+                  lineHeight={"36px"}
+                  width={"100%"}
+                  textAlign={"center"}
+                >
+                  {ageGroupTexts[view]}
+                </Typography>
+              </>
+            )}
+            {containerKeys.map((key, i) => {
+              return (
+                <Fragment key={key}>
+                  {i % 5 === 0 && (
+                    <Grid2 size={5}>
+                      <Typography
+                        fontSize={14}
+                        paddingLeft={1}
+                        fontWeight={"500"}
+                      >
+                        {levels[i / 5].name}
+                      </Typography>
+                    </Grid2>
+                  )}
+                  {view === "all" ? (
+                    <Grid2 size={1} component={"div"}>
+                      <Container id={key} />
+                    </Grid2>
+                  ) : (
+                    <>
+                      {key.split("-")[0] === view && (
+                        <Grid2 size={5} component={"div"}>
+                          <Container id={key} />
+                        </Grid2>
+                      )}
+                    </>
+                  )}
+                </Fragment>
+              );
+            })}
+          </Grid2>
+        </Stack>
+      </LayoutGroup>
+    </DndContext>
   );
 };
 


### PR DESCRIPTION
Introduce drag-and-drop back into the exercise compose view, as we received multiple suggestions that the current setup can be confusing and that users may accidentally switch exercises. 

https://github.com/user-attachments/assets/4de7b2fa-5a7f-42b5-90ab-71cdc50e7cb8

