### PR TITLE
feat: show difficulty numbers and age ranges

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -14,7 +14,6 @@ const config: CodegenConfig = {
       plugins: ["introspection"],
     },
     "src/generated/graphql.tsx": {
-      schema: "./schema.graphql",
       plugins: [
         "typescript",
         "typescript-operations",

--- a/src/components/CategoryDifficultySelect.tsx
+++ b/src/components/CategoryDifficultySelect.tsx
@@ -1,37 +1,69 @@
 import {
-  ExerciseAgeGroup,
   ExerciseDifficultyInput,
+  useSelectExerciseAgeGroupsQuery,
 } from "@/generated/graphql.tsx";
-import { ageGroupTexts } from "@/util/const";
-import { Grid, Stack, Switch, Typography } from "@mui/material";
+import { Alert, Box, Grid, Skeleton, Switch, Typography } from "@mui/material";
 import Radio from "@mui/material/Radio";
 import { blueGrey, brown } from "@mui/material/colors";
 import { ChangeEvent, FC } from "react";
+
+const difficultyValues = [1, 2, 3, 4] as const;
+
+const difficultyGridSx = {
+  display: "grid",
+  gridTemplateColumns: "40px minmax(128px, 1fr) repeat(4, 36px)",
+  alignItems: "center",
+  maxWidth: 420,
+};
 
 export const CategoryDifficultySelect: FC<{
   difficulty: ExerciseDifficultyInput[];
   onChange: (value: ExerciseDifficultyInput[]) => void;
 }> = ({ difficulty, onChange }) => {
+  const { data, loading, error } = useSelectExerciseAgeGroupsQuery();
+
+  if (loading && !data) {
+    return <Skeleton variant="rounded" height={184} />;
+  }
+
+  if (error || !data) {
+    return (
+      <Alert severity="warning">A korcsoportok nem tölthetők be.</Alert>
+    );
+  }
+
+  const ageGroups = [...data.exerciseAgeGroups].sort(
+    (left, right) => left.order - right.order,
+  );
+
   return (
     <Grid container gap={3}>
       <Grid item xs={12}>
-        {Object.entries(ageGroupTexts).map(([ageGroupKey, ageGroup], index) => (
+        <Box sx={difficultyGridSx} aria-hidden="true">
+          <Box sx={{ gridColumn: "1 / 3" }} />
+          {difficultyValues.map((value) => (
+            <Typography key={value} align="center" fontWeight={700}>
+              {value}
+            </Typography>
+          ))}
+        </Box>
+        {ageGroups.map(({ ageGroup, name, gradeRange }) => (
           <ColorRadioButtons
-            key={index}
-            name={ageGroup}
+            key={ageGroup}
+            name={`${name} (${gradeRange})`}
             handleChange={(value) => {
-              if (!difficulty.find((v) => v.ageGroup === ageGroupKey)) {
+              if (!difficulty.find((v) => v.ageGroup === ageGroup)) {
                 onChange([
                   ...difficulty,
                   {
-                    ageGroup: ageGroupKey as ExerciseAgeGroup,
+                    ageGroup,
                     difficulty: parseInt(value),
                   },
                 ]);
                 return;
               }
               const newValues = difficulty.map((v) => {
-                if (v.ageGroup === ageGroupKey) {
+                if (v.ageGroup === ageGroup) {
                   return {
                     ...v,
                     difficulty: parseInt(value),
@@ -44,7 +76,7 @@ export const CategoryDifficultySelect: FC<{
             }}
             selectedValue={
               difficulty
-                .find((value) => value.ageGroup === ageGroupKey)
+                .find((value) => value.ageGroup === ageGroup)
                 ?.difficulty.toString() ?? "0"
             }
           />
@@ -75,25 +107,34 @@ export const ColorRadioButtons = ({
       handleChange(e);
     },
     value: item,
-    inputProps: { "aria-label": item },
+    inputProps: { "aria-label": `${name}, ${item}-es nehézség` },
   });
 
   return (
-    <Stack direction={"row"} alignItems="center">
+    <Box sx={difficultyGridSx}>
       <Switch
+        size="small"
         checked={selectedValue !== "0"}
         onChange={() => propHandleChange(selectedValue === "0" ? "1" : "0")}
+        inputProps={{ "aria-label": `${name} bekapcsolása` }}
       />
       <Typography
-        sx={{ width: "95px", overflow: "hidden", textOverflow: "ellipsis" }}
+        sx={{ whiteSpace: "nowrap", fontSize: { xs: "0.875rem", sm: "1rem" } }}
         color={selectedValue === "0" ? "text.disabled" : undefined}
       >
         {name}
       </Typography>
-      <Radio {...controlProps("1")} color="success" />
+      <Radio
+        {...controlProps("1")}
+        color="success"
+        size="small"
+        sx={{ p: 1 }}
+      />
       <Radio
         {...controlProps("2")}
+        size="small"
         sx={{
+          p: 1,
           color: brown[800],
           "&.Mui-checked": {
             color: brown[600],
@@ -102,14 +143,21 @@ export const ColorRadioButtons = ({
       />
       <Radio
         {...controlProps("3")}
+        size="small"
         sx={{
+          p: 1,
           color: blueGrey[800],
           "&.Mui-checked": {
             color: blueGrey[600],
           },
         }}
       />
-      <Radio {...controlProps("4")} color="warning" />
-    </Stack>
+      <Radio
+        {...controlProps("4")}
+        color="warning"
+        size="small"
+        sx={{ p: 1 }}
+      />
+    </Box>
   );
 };

--- a/src/generated/graphql.schema.json
+++ b/src/generated/graphql.schema.json
@@ -823,6 +823,82 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ExerciseAgeGroupMetadata",
+        "description": null,
+        "isOneOf": null,
+        "fields": [
+          {
+            "name": "ageGroup",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "ENUM",
+                "name": "ExerciseAgeGroup",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "gradeRange",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "order",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "ExerciseAlert",
         "description": null,
         "isOneOf": null,
@@ -5063,6 +5139,30 @@
               "kind": "OBJECT",
               "name": "Exercise",
               "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "exerciseAgeGroups",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "ExerciseAgeGroupMetadata",
+                    "ofType": null
+                  }
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -92,6 +92,14 @@ export type ExerciseAgeGroup =
   | 'MEDVEBOCS'
   | 'NAGYMEDVE';
 
+export type ExerciseAgeGroupMetadata = {
+  __typename: 'ExerciseAgeGroupMetadata';
+  ageGroup: ExerciseAgeGroup;
+  gradeRange: Scalars['String']['output'];
+  name: Scalars['String']['output'];
+  order: Scalars['Int']['output'];
+};
+
 export type ExerciseAlert = {
   __typename: 'ExerciseAlert';
   description: Scalars['String']['output'];
@@ -564,6 +572,7 @@ export type Query = {
   __typename: 'Query';
   commentsByExercise: Array<ExerciseComment>;
   exercise?: Maybe<Exercise>;
+  exerciseAgeGroups: Array<ExerciseAgeGroupMetadata>;
   exerciseComment?: Maybe<ExerciseComment>;
   exerciseHistoryByExercise: Array<ExerciseHistory>;
   exerciseHistoryByField: Array<ExerciseHistory>;
@@ -858,6 +867,11 @@ export type SelectExerciseQueryVariables = Exact<{
 
 
 export type SelectExerciseQuery = { __typename: 'Query', exercise?: { __typename: 'Exercise', id: string, originalId?: string | null, status: ExerciseStatus, description: string, solutionOptions: Array<string>, solution: string, solveIdea?: string | null, source?: string | null, createdAt: string, helpingQuestions: Array<string>, alert?: { __typename: 'ExerciseAlert', description: string, severity: AlertSeverity } | null, sameLogicExerciseGroup?: { __typename: 'SameLogicExerciseGroup', exercises: Array<{ __typename: 'Exercise', id: string, description: string, createdAt: string, difficulty: Array<{ __typename: 'ExerciseDifficulty', difficulty: number, ageGroup: ExerciseAgeGroup }>, exerciseImage?: { __typename: 'Image', url: string } | null, tags: Array<{ __typename: 'Tag', id: string, name: string }>, createdBy: { __typename: 'User', id: string, userName: string, avatarUrl?: string | null } }> } | null, exerciseImage?: { __typename: 'Image', id: string, url: string } | null, solutionImage?: { __typename: 'Image', id: string, url: string } | null, createdBy: { __typename: 'User', id: string, name: string, avatarUrl?: string | null }, contributors: Array<{ __typename: 'User', id: string, name: string, avatarUrl?: string | null }>, solveIdeaImage?: { __typename: 'Image', id: string, url: string } | null, tags: Array<{ __typename: 'Tag', id: string, name: string }>, difficulty: Array<{ __typename: 'ExerciseDifficulty', ageGroup: ExerciseAgeGroup, difficulty: number }>, checks: Array<{ __typename: 'ExerciseCheck', id: string, type: ExerciseCheckType, createdAt: string, updatedAt: string, user: { __typename: 'User', id: string, name: string }, contributors: Array<{ __typename: 'User', id: string, name: string, avatarUrl?: string | null }> }>, comments: Array<{ __typename: 'ExerciseComment', id: string, comment: string, createdAt: string, createdBy: { __typename: 'User', name: string, avatarUrl?: string | null } }> } | null };
+
+export type SelectExerciseAgeGroupsQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type SelectExerciseAgeGroupsQuery = { __typename: 'Query', exerciseAgeGroups: Array<{ __typename: 'ExerciseAgeGroupMetadata', ageGroup: ExerciseAgeGroup, name: string, gradeRange: string, order: number }> };
 
 export type ExerciseHistoryByExerciseQueryVariables = Exact<{
   exerciseId: Scalars['ID']['input'];
@@ -1823,6 +1837,48 @@ export type SelectExerciseQueryHookResult = ReturnType<typeof useSelectExerciseQ
 export type SelectExerciseLazyQueryHookResult = ReturnType<typeof useSelectExerciseLazyQuery>;
 export type SelectExerciseSuspenseQueryHookResult = ReturnType<typeof useSelectExerciseSuspenseQuery>;
 export type SelectExerciseQueryResult = Apollo.QueryResult<SelectExerciseQuery, SelectExerciseQueryVariables>;
+export const SelectExerciseAgeGroupsDocument = gql`
+    query selectExerciseAgeGroups {
+  exerciseAgeGroups {
+    ageGroup
+    name
+    gradeRange
+    order
+  }
+}
+    `;
+
+/**
+ * __useSelectExerciseAgeGroupsQuery__
+ *
+ * To run a query within a React component, call `useSelectExerciseAgeGroupsQuery` and pass it any options that fit your needs.
+ * When your component renders, `useSelectExerciseAgeGroupsQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useSelectExerciseAgeGroupsQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useSelectExerciseAgeGroupsQuery(baseOptions?: Apollo.QueryHookOptions<SelectExerciseAgeGroupsQuery, SelectExerciseAgeGroupsQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<SelectExerciseAgeGroupsQuery, SelectExerciseAgeGroupsQueryVariables>(SelectExerciseAgeGroupsDocument, options);
+      }
+export function useSelectExerciseAgeGroupsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<SelectExerciseAgeGroupsQuery, SelectExerciseAgeGroupsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<SelectExerciseAgeGroupsQuery, SelectExerciseAgeGroupsQueryVariables>(SelectExerciseAgeGroupsDocument, options);
+        }
+export function useSelectExerciseAgeGroupsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<SelectExerciseAgeGroupsQuery, SelectExerciseAgeGroupsQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useSuspenseQuery<SelectExerciseAgeGroupsQuery, SelectExerciseAgeGroupsQueryVariables>(SelectExerciseAgeGroupsDocument, options);
+        }
+export type SelectExerciseAgeGroupsQueryHookResult = ReturnType<typeof useSelectExerciseAgeGroupsQuery>;
+export type SelectExerciseAgeGroupsLazyQueryHookResult = ReturnType<typeof useSelectExerciseAgeGroupsLazyQuery>;
+export type SelectExerciseAgeGroupsSuspenseQueryHookResult = ReturnType<typeof useSelectExerciseAgeGroupsSuspenseQuery>;
+export type SelectExerciseAgeGroupsQueryResult = Apollo.QueryResult<SelectExerciseAgeGroupsQuery, SelectExerciseAgeGroupsQueryVariables>;
 export const ExerciseHistoryByExerciseDocument = gql`
     query ExerciseHistoryByExercise($exerciseId: ID!) {
   exerciseHistoryByExercise(id: $exerciseId) {

--- a/src/graphql/exerciseAgeGroups.graphql
+++ b/src/graphql/exerciseAgeGroups.graphql
@@ -1,0 +1,8 @@
+query selectExerciseAgeGroups {
+  exerciseAgeGroups {
+    ageGroup
+    name
+    gradeRange
+    order
+  }
+}


### PR DESCRIPTION
Closes #27

## What changed

- show difficulty numbers 1–4 above the selector controls
- display backend-provided grade ranges beside each age-group name
- fetch category metadata through a generated GraphQL hook
- add loading and error states
- keep the selector readable at narrow mobile widths
- fix code generation to use the configured schema source

## Validation

- `yarn build`
- targeted ESLint on `CategoryDifficultySelect.tsx`
- responsive interaction QA at desktop, 390 px, and 346 px