### PR TITLE
feat: add exercise sheet content summary

### DIFF
--- a/src/components/compose/Item.tsx
+++ b/src/components/compose/Item.tsx
@@ -10,6 +10,7 @@ import {
 } from "@dnd-kit/core";
 import { CSS } from "@dnd-kit/utilities";
 import { Box, Skeleton, Tooltip } from "@mui/material";
+import { alpha } from "@mui/material/styles";
 import { motion } from "framer-motion";
 import { useAtomValue } from "jotai";
 import { FC, useCallback, useContext, useMemo, useRef } from "react";
@@ -135,7 +136,7 @@ export const Item: FC<{
           touchAction: "none",
         }}
         sx={{
-          transition: "outline 0.2s, background-color 0.2s",
+          transition: "outline 0.2s, box-shadow 0.2s, background-color 0.2s",
           borderRadius: 1,
           border: "1px solid #e0e0e0",
           outline: isSelected
@@ -150,6 +151,11 @@ export const Item: FC<{
                 ? "grabbing"
                 : "grab"
               : "default",
+          '&[data-jump-highlighted="true"]': {
+            outline: (theme) => `3px solid ${theme.palette.primary.main}`,
+            boxShadow: (theme) =>
+              `0 0 0 6px ${alpha(theme.palette.primary.main, 0.3)}`,
+          },
         }}
         onClick={onClick}
         onContextMenu={(e) => {

--- a/src/pages/exerciseSheets/ExerciseSheetList.tsx
+++ b/src/pages/exerciseSheets/ExerciseSheetList.tsx
@@ -1,0 +1,167 @@
+import { KaTeX } from "@/components/Katex";
+import { useSelectExerciseQuery } from "@/generated/graphql.tsx";
+import { composeAtom } from "@/util/atoms";
+import { GpsFixed } from "@mui/icons-material";
+import {
+  Alert,
+  Box,
+  IconButton,
+  Link as MuiLink,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { useAtomValue } from "jotai";
+import { FC, memo, useCallback, useMemo } from "react";
+import { Link } from "react-router-dom";
+
+type ExerciseSheetListRow = {
+  cardId: string;
+  exerciseId: string;
+};
+
+const highlightTimers = new WeakMap<HTMLElement, number>();
+const HIGHLIGHT_DURATION_MS = 2000;
+
+const CountSkeleton = () => <Skeleton width={24} />;
+
+const ExerciseRowComponent: FC<{ row: ExerciseSheetListRow }> = ({ row }) => {
+  const { data, loading } = useSelectExerciseQuery({
+    variables: { exerciseId: row.exerciseId },
+  });
+  const exercise = data?.exercise;
+  const scrollToExercise = useCallback(() => {
+    const target = document.querySelector<HTMLElement>(
+      `[data-card-id="${CSS.escape(row.cardId)}"]`,
+    );
+    if (!target) return;
+
+    const existingTimer = highlightTimers.get(target);
+    if (existingTimer) window.clearTimeout(existingTimer);
+
+    target.dataset.jumpHighlighted = "true";
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    const timer = window.setTimeout(() => {
+      delete target.dataset.jumpHighlighted;
+      highlightTimers.delete(target);
+    }, HIGHLIGHT_DURATION_MS);
+    highlightTimers.set(target, timer);
+  }, [row.cardId]);
+
+  return (
+    <TableRow hover>
+      <TableCell sx={{ width: 58 }}>
+        <MuiLink component={Link} to={`/exercise/${row.exerciseId}`}>
+          #{row.exerciseId}
+        </MuiLink>
+      </TableCell>
+      <TableCell sx={{ width: 160, maxWidth: 160 }}>
+        {loading ? (
+          <Skeleton />
+        ) : exercise ? (
+          <Tooltip title={exercise.description} placement="top">
+            <Typography
+              component="div"
+              variant="body2"
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+              }}
+            >
+              <KaTeX value={exercise.description} />
+            </Typography>
+          </Tooltip>
+        ) : (
+          <Typography color="error" variant="body2">
+            A feladat nem tölthető be
+          </Typography>
+        )}
+      </TableCell>
+      <TableCell align="center">
+        {loading ? <CountSkeleton /> : exercise?.helpingQuestions.length ?? 0}
+      </TableCell>
+      <TableCell align="center">
+        {loading ? <CountSkeleton /> : exercise?.solutionOptions.length ?? 0}
+      </TableCell>
+      <TableCell align="center" sx={{ width: 44, px: 0.5 }}>
+        <Tooltip title={`Ugrás a(z) #${row.exerciseId} feladathoz`}>
+          <IconButton
+            size="small"
+            onClick={scrollToExercise}
+            aria-label={`Ugrás a(z) #${row.exerciseId} feladathoz`}
+          >
+            <GpsFixed fontSize="small" />
+          </IconButton>
+        </Tooltip>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+const ExerciseRow = memo(ExerciseRowComponent);
+
+export const ExerciseSheetList: FC = () => {
+  const items = useAtomValue(composeAtom);
+  const rows = useMemo(
+    () =>
+      Object.values(items).flatMap((exercises) =>
+        exercises.flatMap(({ cardId, id }) =>
+          id
+            ? [
+                {
+                  cardId,
+                  exerciseId: String(id),
+                },
+              ]
+            : [],
+        ),
+      ),
+    [items],
+  );
+
+  if (rows.length === 0) {
+    return (
+      <Box p={2}>
+        <Alert severity="info">A feladatsor még nem tartalmaz feladatot.</Alert>
+      </Box>
+    );
+  }
+
+  return (
+    <TableContainer>
+      <Table size="small" sx={{ tableLayout: "fixed", width: "100%" }}>
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ width: 58 }}>ID</TableCell>
+            <TableCell sx={{ width: 160 }}>Leírás</TableCell>
+            <TableCell
+              align="center"
+              sx={{ width: 72, px: 0.5, whiteSpace: "normal" }}
+            >
+              Segítő kérdések
+            </TableCell>
+            <TableCell
+              align="center"
+              sx={{ width: 72, px: 0.5, whiteSpace: "normal" }}
+            >
+              Válaszopciók
+            </TableCell>
+            <TableCell sx={{ width: 44, px: 0.5 }} />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row) => (
+            <ExerciseRow key={row.cardId} row={row} />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};

--- a/src/pages/exerciseSheets/ExerciseSheetPage.tsx
+++ b/src/pages/exerciseSheets/ExerciseSheetPage.tsx
@@ -220,32 +220,6 @@ export const ExerciseSheetPage: FC = () => {
         )}
         <Box flexGrow={1} />
         <Stack direction={"row"} gap={2}>
-          {/* <ToggleButtonGroup
-            value={exerciseView}
-            exclusive
-            onChange={(_, value) => {
-              setValue({ exerciseView: value });
-              clear();
-            }}
-            sx={{ background: "background" }}
-          >
-            <ToggleButton
-              size="small"
-              sx={{ px: 2 }}
-              value={ExerciseView.CARD}
-              selected={exerciseView === ExerciseView.CARD}
-            >
-              Kártya
-            </ToggleButton>
-            <ToggleButton
-              size="small"
-              sx={{ px: 2 }}
-              value={ExerciseView.LIST}
-              selected={exerciseView === ExerciseView.LIST}
-            >
-              Lista
-            </ToggleButton>
-          </ToggleButtonGroup> */}
           <LoadingButton
             onClick={save}
             variant="contained"

--- a/src/pages/exerciseSheets/SheetOperations.tsx
+++ b/src/pages/exerciseSheets/SheetOperations.tsx
@@ -2,6 +2,7 @@ import { CommentSection } from "@/components/CommentSection";
 import { ExerciseSheetQuery } from "@/generated/graphql";
 import { Box, Card, Stack, Tooltip } from "@mui/material";
 import { FC } from "react";
+import { ExerciseSheetList } from "./ExerciseSheetList";
 import { SheetStatusSelector } from "./SheetStatusSelector";
 
 export const SheetOperations: FC<{
@@ -10,7 +11,7 @@ export const SheetOperations: FC<{
   sheet = sheet!;
 
   return (
-    <>
+    <Stack gap={2}>
       <Card
         sx={{ borderRadius: { xs: 0, md: 1 }, border: "1px solid #e0e0e0" }}
       >
@@ -39,6 +40,14 @@ export const SheetOperations: FC<{
           />
         </Stack>
       </Card>
-    </>
+      <Card
+        sx={{
+          borderRadius: { xs: 0, md: 1 },
+          border: "1px solid #e0e0e0",
+        }}
+      >
+        <ExerciseSheetList />
+      </Card>
+    </Stack>
   );
 };


### PR DESCRIPTION
## Summary

- add a compact exercise summary table below the **Státusz** card
- show each exercise ID, truncated description, helping-question count, and answer-option count
- add jump-to-exercise navigation with a brief highlight
- link IDs to the existing exercise detail route

<img width="1512" height="736" alt="image" src="https://github.com/user-attachments/assets/5ce5ded6-788a-44ff-a328-9dc56641943a" />


Closes mok-it/feladatsor#10