### PR TITLE
fix: stop 404 dino game after navigation

### DIFF
--- a/src/components/404.tsx
+++ b/src/components/404.tsx
@@ -5,13 +5,70 @@ import {
 } from "@/generated/graphql";
 import { Box, LinearProgress, Stack, Typography } from "@mui/material";
 import { useSnackbar } from "notistack";
-import { FC, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import DinoGame from "react-chrome-dino-ts";
 import "react-chrome-dino-ts/index.css";
+
+type DinoRunner = {
+  audioContext: AudioContext | null;
+  play: () => void;
+  resizeTimerId_: ReturnType<typeof setInterval> | null;
+  stop: () => void;
+  stopListening: () => void;
+};
+
+type DinoRunnerConstructor = {
+  instance_?: DinoRunner | null;
+};
+
+const getDinoRunner = () =>
+  (window as Window & { Runner?: DinoRunnerConstructor }).Runner;
+
+const cleanupDinoRunner = (runner: DinoRunner | null | undefined) => {
+  if (!runner) {
+    return;
+  }
+
+  runner.stop();
+  runner.stopListening();
+
+  // The package registers bound focus handlers that cannot be removed.
+  // Prevent them from restarting this unmounted runner.
+  runner.play = () => undefined;
+
+  if (runner.resizeTimerId_) {
+    clearInterval(runner.resizeTimerId_);
+  }
+
+  const { audioContext } = runner;
+  if (audioContext && audioContext.state !== "closed") {
+    void audioContext.close();
+  }
+
+  const Runner = getDinoRunner();
+  if (Runner?.instance_ === runner) {
+    Runner.instance_ = null;
+  }
+};
 
 export const Page404: FC = () => {
   const [choice, setChoice] = useState<string | null>(null);
   const [voted, setVoted] = useState(false);
+  const cleanupTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (cleanupTimer.current) {
+      clearTimeout(cleanupTimer.current);
+      cleanupTimer.current = null;
+    }
+
+    return () => {
+      // Deferring lets React Strict Mode's immediate effect replay cancel the
+      // cleanup while still cleaning up after an actual navigation.
+      const runner = getDinoRunner()?.instance_;
+      cleanupTimer.current = setTimeout(() => cleanupDinoRunner(runner));
+    };
+  }, []);
 
   const { data } = useFunkyPoolQuery();
   const [mutate] = useVoteOnDeveloperMutation({


### PR DESCRIPTION
Closes #29

## What changed

- stop the dinosaur game's animation loop when the 404 page unmounts
- remove its document-level keyboard and mouse listeners
- close its audio context and clear pending resize work
- prevent stale focus listeners from restarting an unmounted runner
- reset the package singleton so revisiting the 404 page creates a fresh game
- defer cleanup through React Strict Mode's development effect replay

## Root cause

`react-chrome-dino-ts` creates a global `Runner` singleton and registers document/window listeners, but it does not clean them up when its React component unmounts. As a result, Space-key handling and sounds continued after navigation.

## Validation

- `yarn eslint src/components/404.tsx --ext ts,tsx --report-unused-disable-directives --max-warnings 0`
- `yarn build`
- browser QA: start the dinosaur with Space, navigate away through React Router, press Space again; destination remains stable with no canvas or console errors

The repository-wide `yarn lint` remains blocked by 82 pre-existing warnings in unrelated/generated files.