### PR TITLE
feat: Persist page filters in query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "yarn && tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "test": "node --test tests/*.test.ts",
     "preview": "vite preview",
     "codegen": "graphql-codegen --config codegen.ts"
   },

--- a/src/components/exercise/ExerciseTable.tsx
+++ b/src/components/exercise/ExerciseTable.tsx
@@ -74,8 +74,7 @@ export const ExerciseTable: FC<
   order,
   orderBy,
   selectedId,
-  setOrder,
-  setOrderBy,
+  setSorting,
   onRowSelect,
 }) => {
   const isMobile = useMediaQuery("(max-width: 1200px)");
@@ -100,10 +99,10 @@ export const ExerciseTable: FC<
                   value={orderBy ?? ""}
                   sx={{ mr: 1, mb: 1, bgcolor: "background.paper" }}
                   onChange={(e) => {
-                    setOrderBy(
+                    setSorting(
                       e.target.value as keyof ExerciseListElemFragment,
+                      "asc",
                     );
-                    setOrder("asc");
                   }}
                 >
                   {headCells
@@ -120,7 +119,7 @@ export const ExerciseTable: FC<
                   value={order}
                   sx={{ mr: 1, mb: 1, bgcolor: "background.paper" }}
                   onChange={() => {
-                    setOrder(order === "asc" ? "desc" : "asc");
+                    setSorting(orderBy, order === "asc" ? "desc" : "asc");
                   }}
                 >
                   <option value="asc">Növekvő</option>
@@ -143,8 +142,12 @@ export const ExerciseTable: FC<
                       active={orderBy === headCell.id}
                       direction={orderBy === headCell.id ? order : "asc"}
                       onClick={() => {
-                        setOrderBy(headCell.id);
-                        setOrder(order === "asc" ? "desc" : "asc");
+                        setSorting(
+                          headCell.id,
+                          orderBy === headCell.id && order === "asc"
+                            ? "desc"
+                            : "asc",
+                        );
                       }}
                     >
                       {headCell.label}

--- a/src/pages/ExerciseCheck/ExerciseCheckPage.tsx
+++ b/src/pages/ExerciseCheck/ExerciseCheckPage.tsx
@@ -5,6 +5,7 @@ import {
   useSearchExercisesLazyQuery,
 } from "@/generated/graphql.tsx";
 import { ExerciseStatusEnum } from "@/util/types";
+import { exerciseSortKeys } from "@/util/exerciseSearchParams";
 import { useExerciseFilters } from "@/util/useExerciseFilters";
 import { useTableOrder } from "@/util/useTableOrder";
 import { Card, CardContent, CardHeader, Typography } from "@mui/material";
@@ -15,8 +16,12 @@ const LIMIT = 20;
 export const ExerciseCheckPage = () => {
   const { exerciseQuery, difficulty, filterComponents } = useExerciseFilters({
     checkStatus: true,
+    persistInUrl: true,
   });
-  const tableOrder = useTableOrder<ExerciseListElemFragment>();
+  const tableOrder = useTableOrder<ExerciseListElemFragment>({
+    persistInUrl: true,
+    allowedOrderBy: exerciseSortKeys,
+  });
   const { orderBy, order } = tableOrder;
 
   const [getData, { loading }] = useSearchExercisesLazyQuery({

--- a/src/pages/ExerciseListPage/DifficultySelector.tsx
+++ b/src/pages/ExerciseListPage/DifficultySelector.tsx
@@ -1,6 +1,7 @@
-import { ExerciseAgeGroup } from "@/generated/graphql.tsx";
+import type { ExerciseAgeGroup } from "@/generated/graphql.tsx";
 import { ageGroupTexts } from "@/util/const";
 import { Slider, Stack, Switch, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
 
 export const DifficultySelector = (props: {
   ageGroup: ExerciseAgeGroup;
@@ -9,6 +10,12 @@ export const DifficultySelector = (props: {
   isEnabled: boolean;
   setIsEnabled: (isEnabled: boolean) => void;
 }) => {
+  const [sliderValue, setSliderValue] = useState(props.difficulty);
+
+  useEffect(() => {
+    setSliderValue(props.difficulty);
+  }, [props.difficulty]);
+
   return (
     <Stack direction={"row"} alignItems={"center"} pr={4}>
       <Stack
@@ -37,8 +44,11 @@ export const DifficultySelector = (props: {
       <Slider
         disabled={!props.isEnabled}
         name="Nehézség"
-        value={props.difficulty}
-        onChange={(_, value) => props.setDifficulty(value as [number, number])}
+        value={sliderValue}
+        onChange={(_, value) => setSliderValue(value as [number, number])}
+        onChangeCommitted={(_, value) =>
+          props.setDifficulty(value as [number, number])
+        }
         step={1}
         min={0}
         max={4}

--- a/src/pages/ExerciseListPage/ExerciseListPage.tsx
+++ b/src/pages/ExerciseListPage/ExerciseListPage.tsx
@@ -5,6 +5,7 @@ import {
   useSearchExercisesLazyQuery,
 } from "@/generated/graphql.tsx";
 import { useExerciseFilters } from "@/util/useExerciseFilters";
+import { exerciseSortKeys } from "@/util/exerciseSearchParams";
 import { useTableOrder } from "@/util/useTableOrder";
 import { Card, CardContent, CardHeader, Typography } from "@mui/material";
 import { useCallback, useEffect } from "react";
@@ -12,8 +13,13 @@ import { useCallback, useEffect } from "react";
 const LIMIT = 20;
 
 export const ExerciseListPage = () => {
-  const { exerciseQuery, difficulty, filterComponents } = useExerciseFilters();
-  const tableOrder = useTableOrder<ExerciseListElemFragment>();
+  const { exerciseQuery, difficulty, filterComponents } = useExerciseFilters({
+    persistInUrl: true,
+  });
+  const tableOrder = useTableOrder<ExerciseListElemFragment>({
+    persistInUrl: true,
+    allowedOrderBy: exerciseSortKeys,
+  });
   const { orderBy, order } = tableOrder;
 
   const [getData, { loading }] = useSearchExercisesLazyQuery({

--- a/src/pages/Reporting/ExerciseReportingByUsers.tsx
+++ b/src/pages/Reporting/ExerciseReportingByUsers.tsx
@@ -18,8 +18,18 @@ import {
   Typography,
 } from "@mui/material";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useSelectExercisesQuery } from "@/generated/graphql.tsx";
+import { useSearchParams } from "react-router-dom";
+import {
+  formatLocalDate,
+  getQuickReportDateRange,
+  parseLocalDate,
+  parseReportDateRange,
+  type QuickDateRange,
+  type ReportDateRange,
+  writeReportDateRange,
+} from "./reportDateParams";
 
 interface UserExerciseStats {
   userId: string;
@@ -30,49 +40,6 @@ interface UserExerciseStats {
   collaborativeExercises: number;
   score: number;
 }
-
-interface DateRange {
-  startDate: Date;
-  endDate: Date;
-}
-
-type QuickDateRange =
-  | "today"
-  | "yesterday"
-  | "last3days"
-  | "lastWeek"
-  | "lastMonth";
-
-const getQuickDateRange = (range: QuickDateRange): DateRange => {
-  const today = new Date();
-  const endDate = new Date();
-  let startDate = new Date();
-
-  switch (range) {
-    case "today":
-      startDate = new Date(today);
-      break;
-    case "yesterday":
-      startDate = new Date(today);
-      startDate.setDate(today.getDate() - 1);
-      endDate.setDate(today.getDate() - 1);
-      break;
-    case "last3days":
-      startDate = new Date(today);
-      startDate.setDate(today.getDate() - 3);
-      break;
-    case "lastWeek":
-      startDate = new Date(today);
-      startDate.setDate(today.getDate() - 7);
-      break;
-    case "lastMonth":
-      startDate = new Date(today);
-      startDate.setMonth(today.getMonth() - 1);
-      break;
-  }
-
-  return { startDate, endDate };
-};
 
 const calculateUserStats = (
   exercises: Array<{
@@ -155,14 +122,27 @@ const calculateUserStats = (
 };
 
 export const ExerciseReportingByUsers = () => {
-  const [dateRange, setDateRange] = useState<DateRange>({
-    startDate: new Date(new Date().setMonth(new Date().getMonth() - 1)),
-    endDate: new Date(),
-  });
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dateRange = useMemo(
+    () => parseReportDateRange(searchParams),
+    [searchParams],
+  );
 
-  const handleQuickDateRange = useCallback((range: QuickDateRange) => {
-    setDateRange(getQuickDateRange(range));
-  }, []);
+  const setDateRange = useCallback(
+    (range: ReportDateRange) => {
+      const nextParams = new URLSearchParams(searchParams);
+      writeReportDateRange(nextParams, range);
+      setSearchParams(nextParams);
+    },
+    [searchParams, setSearchParams],
+  );
+
+  const handleQuickDateRange = useCallback(
+    (range: QuickDateRange) => {
+      setDateRange(getQuickReportDateRange(range));
+    },
+    [setDateRange],
+  );
 
   const { data, loading } = useSelectExercisesQuery({
     variables: {
@@ -193,34 +173,32 @@ export const ExerciseReportingByUsers = () => {
           <TextField
             label="Kezdő dátum"
             type="date"
-            value={dateRange.startDate.toISOString().split("T")[0]}
-            onChange={(e) =>
-              setDateRange((prev) => {
-                const startDate = new Date(e.target.value);
-                return {
-                  ...prev,
-                  //@ts-expect-error TS doesn't recognize isNaN for Date
-                  startDate: !isNaN(startDate) ? startDate : prev.startDate,
-                };
-              })
-            }
+            value={formatLocalDate(dateRange.startDate)}
+            onChange={(event) => {
+              const startDate = parseLocalDate(event.target.value);
+              if (!startDate) return;
+              setDateRange({
+                startDate,
+                endDate:
+                  startDate > dateRange.endDate ? startDate : dateRange.endDate,
+              });
+            }}
             slotProps={{ inputLabel: { shrink: true } }}
             size="small"
           />
           <TextField
             label="Vége dátum"
             type="date"
-            value={dateRange.endDate.toISOString().split("T")[0]}
-            onChange={(e) =>
-              setDateRange((prev) => {
-                const endDate = new Date(e.target.value);
-                return {
-                  ...prev,
-                  //@ts-expect-error TS doesn't recognize isNaN for Date
-                  endDate: !isNaN(endDate) ? endDate : prev.endDate,
-                };
-              })
-            }
+            value={formatLocalDate(dateRange.endDate)}
+            onChange={(event) => {
+              const endDate = parseLocalDate(event.target.value);
+              if (!endDate) return;
+              setDateRange({
+                startDate:
+                  endDate < dateRange.startDate ? endDate : dateRange.startDate,
+                endDate,
+              });
+            }}
             slotProps={{ inputLabel: { shrink: true } }}
             size="small"
           />

--- a/src/pages/Reporting/reportDateParams.ts
+++ b/src/pages/Reporting/reportDateParams.ts
@@ -1,0 +1,114 @@
+export interface ReportDateRange {
+  startDate: Date;
+  endDate: Date;
+}
+
+export type QuickDateRange =
+  | "today"
+  | "yesterday"
+  | "last3days"
+  | "lastWeek"
+  | "lastMonth";
+
+const datePattern = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const startOfLocalDay = (date: Date) =>
+  new Date(date.getFullYear(), date.getMonth(), date.getDate());
+
+export const formatLocalDate = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+export const parseLocalDate = (value: string): Date | null => {
+  const match = datePattern.exec(value);
+  if (!match) return null;
+
+  const [, yearValue, monthValue, dayValue] = match;
+  const year = Number(yearValue);
+  const month = Number(monthValue);
+  const day = Number(dayValue);
+  const date = new Date(year, month - 1, day);
+
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== month - 1 ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+};
+
+export const getDefaultReportDateRange = (
+  now = new Date(),
+): ReportDateRange => {
+  const endDate = startOfLocalDay(now);
+  const startDate = new Date(endDate);
+  startDate.setMonth(startDate.getMonth() - 1);
+  return { startDate, endDate };
+};
+
+export const getQuickReportDateRange = (
+  range: QuickDateRange,
+  now = new Date(),
+): ReportDateRange => {
+  const today = startOfLocalDay(now);
+  const startDate = new Date(today);
+  const endDate = new Date(today);
+
+  switch (range) {
+    case "today":
+      break;
+    case "yesterday":
+      startDate.setDate(today.getDate() - 1);
+      endDate.setDate(today.getDate() - 1);
+      break;
+    case "last3days":
+      startDate.setDate(today.getDate() - 3);
+      break;
+    case "lastWeek":
+      startDate.setDate(today.getDate() - 7);
+      break;
+    case "lastMonth":
+      startDate.setMonth(today.getMonth() - 1);
+      break;
+  }
+
+  return { startDate, endDate };
+};
+
+export const parseReportDateRange = (
+  params: URLSearchParams,
+  now = new Date(),
+): ReportDateRange => {
+  const defaults = getDefaultReportDateRange(now);
+  const startDate =
+    parseLocalDate(params.get("from") ?? "") ?? defaults.startDate;
+  const endDate = parseLocalDate(params.get("to") ?? "") ?? defaults.endDate;
+
+  return startDate <= endDate ? { startDate, endDate } : defaults;
+};
+
+export const writeReportDateRange = (
+  params: URLSearchParams,
+  range: ReportDateRange,
+  now = new Date(),
+) => {
+  params.delete("from");
+  params.delete("to");
+
+  const defaults = getDefaultReportDateRange(now);
+  const startDate = formatLocalDate(range.startDate);
+  const endDate = formatLocalDate(range.endDate);
+
+  if (startDate !== formatLocalDate(defaults.startDate)) {
+    params.set("from", startDate);
+  }
+  if (endDate !== formatLocalDate(defaults.endDate)) {
+    params.set("to", endDate);
+  }
+};

--- a/src/pages/TagsPage.tsx
+++ b/src/pages/TagsPage.tsx
@@ -241,7 +241,7 @@ const TagLabel: FC<{
         </form>
       ) : (
         <Stack direction={"row"} alignItems={"center"} gap={1}>
-          <Link to={`/list-exercises?tag=${tag.id}`}>
+          <Link to={`/list-exercises?includeTag=${tag.id}`}>
             <Chip
               sx={{ cursor: "pointer" }}
               label={`${tag.name} ${tag.exerciseCount ? `(${tag.exerciseCount} db)` : ""}`}

--- a/src/util/const.ts
+++ b/src/util/const.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   Exercise,
   ExerciseAgeGroup,
   ExerciseCheckType,
   ExerciseStatus,
 } from "@/generated/graphql";
-import { ExerciseFieldsType, ExerciseQuery } from "./types";
+import type { ExerciseFieldsType, ExerciseQuery } from "./types";
 
 export const levels: { [key in number]: { name: string } } = {
   0: { name: "Zöld" },

--- a/src/util/exerciseSearchParams.ts
+++ b/src/util/exerciseSearchParams.ts
@@ -1,0 +1,153 @@
+import type {
+  ExerciseAgeGroup,
+  ExerciseCheckFilter,
+} from "../generated/graphql.tsx";
+import { searchDefaultValues } from "./const.ts";
+import type { ExerciseQuery } from "./types.ts";
+
+export const exerciseSortKeys = [
+  "id",
+  "status",
+  "description",
+  "createdAt",
+] as const;
+
+export type ExerciseSortKey = (typeof exerciseSortKeys)[number];
+export type ExerciseSortDirection = "asc" | "desc";
+
+const ageGroups: ExerciseAgeGroup[] = [
+  "KOALA",
+  "MEDVEBOCS",
+  "KISMEDVE",
+  "NAGYMEDVE",
+  "JEGESMEDVE",
+];
+
+const checkStatuses: ExerciseCheckFilter[] = [
+  "NEEDS_TO_BE_CHECKED",
+  "GOOD",
+  "CHANGE_REQUIRED",
+  "TO_DELETE",
+];
+
+const difficultyPattern = /^([A-Z]+):(\d)-(\d)$/;
+
+export const createDefaultExerciseQuery = (
+  includeCheckStatus = false,
+): ExerciseQuery => ({
+  ...searchDefaultValues,
+  difficulty: Object.fromEntries(
+    ageGroups.map((ageGroup) => [
+      ageGroup,
+      {
+        ...searchDefaultValues.difficulty[ageGroup],
+        difficulty: [
+          ...searchDefaultValues.difficulty[ageGroup].difficulty,
+        ] as [number, number],
+      },
+    ]),
+  ) as ExerciseQuery["difficulty"],
+  ...(includeCheckStatus ? { checkStatus: "" } : {}),
+});
+
+export const parseExerciseFilters = (
+  params: URLSearchParams,
+  includeCheckStatus = false,
+): ExerciseQuery => {
+  const query = createDefaultExerciseQuery(includeCheckStatus);
+  query.searchQuery = params.get("q") ?? "";
+  query.includeTags = [...new Set(params.getAll("includeTag").filter(Boolean))];
+  query.excludeTags = [
+    ...new Set(
+      params
+        .getAll("excludeTag")
+        .filter((tagId) => tagId && !query.includeTags.includes(tagId)),
+    ),
+  ];
+
+  params.getAll("difficulty").forEach((value) => {
+    const match = difficultyPattern.exec(value);
+    if (!match) return;
+
+    const [, ageGroupValue, minValue, maxValue] = match;
+    if (!ageGroups.includes(ageGroupValue as ExerciseAgeGroup)) return;
+
+    const min = Number(minValue);
+    const max = Number(maxValue);
+    if (min < 0 || max > 4 || min > max) return;
+
+    const ageGroup = ageGroupValue as ExerciseAgeGroup;
+    query.difficulty[ageGroup] = {
+      difficulty: [min, max],
+      isEnabled: true,
+    };
+  });
+
+  if (includeCheckStatus) {
+    const checkStatus = params.get("check");
+    query.checkStatus = checkStatuses.includes(
+      checkStatus as ExerciseCheckFilter,
+    )
+      ? (checkStatus as ExerciseCheckFilter)
+      : "";
+  }
+
+  return query;
+};
+
+export const writeExerciseFilters = (
+  params: URLSearchParams,
+  query: ExerciseQuery,
+  includeCheckStatus = false,
+) => {
+  ["q", "tag", "includeTag", "excludeTag", "difficulty", "check"].forEach(
+    (key) => params.delete(key),
+  );
+
+  if (query.searchQuery) params.set("q", query.searchQuery);
+  query.includeTags.forEach((tagId) => params.append("includeTag", tagId));
+  query.excludeTags
+    .filter((tagId) => !query.includeTags.includes(tagId))
+    .forEach((tagId) => params.append("excludeTag", tagId));
+
+  ageGroups.forEach((ageGroup) => {
+    const difficulty = query.difficulty[ageGroup];
+    if (!difficulty.isEnabled) return;
+    params.append(
+      "difficulty",
+      `${ageGroup}:${difficulty.difficulty[0]}-${difficulty.difficulty[1]}`,
+    );
+  });
+
+  if (includeCheckStatus && query.checkStatus) {
+    params.set("check", query.checkStatus);
+  }
+};
+
+export const parseExerciseSorting = (
+  params: URLSearchParams,
+): { orderBy: ExerciseSortKey | null; order: ExerciseSortDirection } => {
+  const orderByValue = params.get("sort");
+  const order = params.get("dir");
+  const orderBy = exerciseSortKeys.includes(orderByValue as ExerciseSortKey)
+    ? (orderByValue as ExerciseSortKey)
+    : null;
+
+  return {
+    orderBy,
+    order: orderBy && order === "desc" ? "desc" : "asc",
+  };
+};
+
+export const writeExerciseSorting = (
+  params: URLSearchParams,
+  orderBy: ExerciseSortKey | null,
+  order: ExerciseSortDirection,
+) => {
+  params.delete("sort");
+  params.delete("dir");
+
+  if (!orderBy) return;
+  params.set("sort", orderBy);
+  if (order === "desc") params.set("dir", order);
+};

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,7 +1,7 @@
-import {
+import type {
   Exercise,
   ExerciseAgeGroup,
-  ExerciseCheckType,
+  ExerciseCheckFilter,
 } from "@/generated/graphql";
 
 declare global {
@@ -55,7 +55,7 @@ export type ExerciseQuery = {
   isFinal: boolean;
   includeTags: string[];
   excludeTags: string[];
-  checkStatus?: ExerciseCheckType | "";
+  checkStatus?: ExerciseCheckFilter | "";
   approveCount?: number;
 };
 

--- a/src/util/useExerciseFilters.tsx
+++ b/src/util/useExerciseFilters.tsx
@@ -14,22 +14,68 @@ import {
   Tooltip,
   useMediaQuery,
 } from "@mui/material";
+import { produce } from "immer";
 import { entries } from "lodash";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { IoSearch } from "react-icons/io5";
-import { useSearchParam } from "react-use";
-import { useImmer } from "use-immer";
-import { searchDefaultValues, translateCheck } from "./const";
+import { useSearchParams } from "react-router-dom";
+import { useImmer, type Updater } from "use-immer";
+import { translateCheck } from "./const";
+import {
+  createDefaultExerciseQuery,
+  parseExerciseFilters,
+  writeExerciseFilters,
+} from "./exerciseSearchParams";
 import { ExerciseQuery } from "./types";
 
-export const useExerciseFilters = (props?: { checkStatus: boolean }) => {
+export const useExerciseFilters = (props?: {
+  checkStatus?: boolean;
+  persistInUrl?: boolean;
+}) => {
   const isMobile = useMediaQuery("(max-width: 900px)");
-  const paramTag = useSearchParam("tag");
-  const [exerciseQuery, setExerciseQuery] = useImmer<ExerciseQuery>({
-    ...searchDefaultValues,
-    ...(paramTag ? { includeTags: [paramTag] } : {}),
-    ...(props?.checkStatus ? { checkStatus: "" } : {}),
-  });
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [localExerciseQuery, setLocalExerciseQuery] = useImmer<ExerciseQuery>(
+    () => createDefaultExerciseQuery(props?.checkStatus),
+  );
+
+  const urlExerciseQuery = useMemo(
+    () => parseExerciseFilters(searchParams, props?.checkStatus),
+    [props?.checkStatus, searchParams],
+  );
+  const exerciseQuery = props?.persistInUrl
+    ? urlExerciseQuery
+    : localExerciseQuery;
+
+  const updateUrlExerciseQuery = useCallback(
+    (update: Parameters<Updater<ExerciseQuery>>[0], replace: boolean) => {
+      const nextQuery =
+        typeof update === "function" ? produce(exerciseQuery, update) : update;
+      const nextParams = new URLSearchParams(searchParams);
+      writeExerciseFilters(nextParams, nextQuery, props?.checkStatus);
+      setSearchParams(nextParams, { replace });
+    },
+    [exerciseQuery, props?.checkStatus, searchParams, setSearchParams],
+  );
+  const setUrlExerciseQuery = useCallback<Updater<ExerciseQuery>>(
+    (update) => updateUrlExerciseQuery(update, false),
+    [updateUrlExerciseQuery],
+  );
+  const setExerciseQuery = props?.persistInUrl
+    ? setUrlExerciseQuery
+    : setLocalExerciseQuery;
+  const setSearchQuery = useCallback(
+    (searchQuery: string) => {
+      const update = (draft: ExerciseQuery) => {
+        draft.searchQuery = searchQuery;
+      };
+      if (props?.persistInUrl) {
+        updateUrlExerciseQuery(update, true);
+      } else {
+        setLocalExerciseQuery(update);
+      }
+    },
+    [props?.persistInUrl, setLocalExerciseQuery, updateUrlExerciseQuery],
+  );
   const { data: tags } = useFlatExerciseTagsQuery();
 
   const difficulty = useMemo(() => {
@@ -49,9 +95,7 @@ export const useExerciseFilters = (props?: { checkStatus: boolean }) => {
       <Stack gap={1}>
         <TextField
           onChange={(event) => {
-            setExerciseQuery((draft) => {
-              draft.searchQuery = event.target.value;
-            });
+            setSearchQuery(event.target.value);
           }}
           label="Keresés"
           value={exerciseQuery.searchQuery}
@@ -73,7 +117,7 @@ export const useExerciseFilters = (props?: { checkStatus: boolean }) => {
             orientation={isMobile ? "vertical" : "horizontal"}
             onChange={(_, value) => {
               setExerciseQuery((draft) => {
-                draft.checkStatus = value;
+                draft.checkStatus = value ?? "";
               });
             }}
           >
@@ -112,7 +156,6 @@ export const useExerciseFilters = (props?: { checkStatus: boolean }) => {
             </Tooltip>
           </ToggleButtonGroup>
         )}
-        {exerciseQuery.searchQuery}
         <SimpleAccordion summary="Nehézség szűrő">
           <DifficultySelectorList
             difficulties={exerciseQuery.difficulty}
@@ -121,7 +164,7 @@ export const useExerciseFilters = (props?: { checkStatus: boolean }) => {
         </SimpleAccordion>
         <SimpleAccordion
           summary="Címke szűrő"
-          defaultExpanded={paramTag !== null}
+          defaultExpanded={exerciseQuery.includeTags.length > 0}
         >
           {tags && (
             <TagSelector
@@ -141,9 +184,9 @@ export const useExerciseFilters = (props?: { checkStatus: boolean }) => {
     exerciseQuery.includeTags,
     exerciseQuery.searchQuery,
     isMobile,
-    paramTag,
     props?.checkStatus,
     setExerciseQuery,
+    setSearchQuery,
     tags,
   ]);
 

--- a/src/util/useTableOrder.ts
+++ b/src/util/useTableOrder.ts
@@ -1,15 +1,69 @@
-import { useState } from "react";
+import {
+  parseExerciseSorting,
+  writeExerciseSorting,
+} from "@/util/exerciseSearchParams";
+import type {
+  ExerciseSortDirection,
+  ExerciseSortKey,
+} from "@/util/exerciseSearchParams";
+import { useCallback, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 
 export type TableOrder<T> = {
   orderBy: keyof T | null;
   order: "asc" | "desc";
   setOrderBy: (key: keyof T) => void;
   setOrder: (dir: "asc" | "desc") => void;
+  setSorting: (key: keyof T | null, dir: "asc" | "desc") => void;
 };
 
-export const useTableOrder = <T>(): TableOrder<T> => {
-  const [orderBy, setOrderBy] = useState<keyof T | null>(null);
-  const [order, setOrder] = useState<"asc" | "desc">("asc");
+export const useTableOrder = <T>(options?: {
+  persistInUrl?: boolean;
+  allowedOrderBy?: readonly (keyof T)[];
+}): TableOrder<T> => {
+  const [localOrderBy, setLocalOrderBy] = useState<keyof T | null>(null);
+  const [localOrder, setLocalOrder] = useState<ExerciseSortDirection>("asc");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const urlSorting = useMemo(
+    () => parseExerciseSorting(searchParams),
+    [searchParams],
+  );
+  const urlOrderBy = options?.allowedOrderBy?.includes(
+    urlSorting.orderBy as keyof T,
+  )
+    ? (urlSorting.orderBy as keyof T)
+    : null;
 
-  return { orderBy, order, setOrderBy, setOrder };
+  const orderBy = options?.persistInUrl ? urlOrderBy : localOrderBy;
+  const order = options?.persistInUrl ? urlSorting.order : localOrder;
+
+  const setSorting = useCallback(
+    (key: keyof T | null, direction: ExerciseSortDirection) => {
+      if (!options?.persistInUrl) {
+        setLocalOrderBy(key);
+        setLocalOrder(direction);
+        return;
+      }
+
+      const nextParams = new URLSearchParams(searchParams);
+      writeExerciseSorting(
+        nextParams,
+        key as ExerciseSortKey | null,
+        direction,
+      );
+      setSearchParams(nextParams);
+    },
+    [options?.persistInUrl, searchParams, setSearchParams],
+  );
+
+  const setOrderBy = useCallback(
+    (key: keyof T) => setSorting(key, order),
+    [order, setSorting],
+  );
+  const setOrder = useCallback(
+    (direction: ExerciseSortDirection) => setSorting(orderBy, direction),
+    [orderBy, setSorting],
+  );
+
+  return { orderBy, order, setOrderBy, setOrder, setSorting };
 };

--- a/tests/exerciseSearchParams.test.ts
+++ b/tests/exerciseSearchParams.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  createDefaultExerciseQuery,
+  parseExerciseFilters,
+  parseExerciseSorting,
+  writeExerciseFilters,
+  writeExerciseSorting,
+} from "../src/util/exerciseSearchParams.ts";
+
+test("filter state round-trips through query parameters", () => {
+  const query = createDefaultExerciseQuery(true);
+  query.searchQuery = "geometry";
+  query.includeTags = ["12", "18"];
+  query.excludeTags = ["25"];
+  query.difficulty.KOALA = {
+    difficulty: [1, 3],
+    isEnabled: true,
+  };
+  query.checkStatus = "CHANGE_REQUIRED";
+
+  const params = new URLSearchParams("sort=createdAt&dir=desc");
+  writeExerciseFilters(params, query, true);
+
+  assert.equal(
+    params.toString(),
+    "sort=createdAt&dir=desc&q=geometry&includeTag=12&includeTag=18&excludeTag=25&difficulty=KOALA%3A1-3&check=CHANGE_REQUIRED",
+  );
+  assert.deepEqual(parseExerciseFilters(params, true), query);
+});
+
+test("invalid and conflicting filter parameters fall back safely", () => {
+  const params = new URLSearchParams(
+    "tag=legacy&includeTag=12&includeTag=12&excludeTag=12&excludeTag=25&difficulty=UNKNOWN:1-2&difficulty=KOALA:4-2&difficulty=KISMEDVE:0-5&check=INVALID",
+  );
+
+  const parsed = parseExerciseFilters(params, true);
+
+  assert.deepEqual(parsed.includeTags, ["12"]);
+  assert.deepEqual(parsed.excludeTags, ["25"]);
+  assert.equal(parsed.checkStatus, "");
+  assert.equal(parsed.difficulty.KOALA.isEnabled, false);
+  assert.equal(parsed.difficulty.KISMEDVE.isEnabled, false);
+
+  writeExerciseFilters(params, parsed, true);
+  assert.equal(params.has("tag"), false);
+  assert.equal(params.has("check"), false);
+});
+
+test("default filter state produces no filter parameters", () => {
+  const params = new URLSearchParams("sort=id");
+  writeExerciseFilters(params, createDefaultExerciseQuery(), false);
+  assert.equal(params.toString(), "sort=id");
+});
+
+test("sorting validates fields and omits default direction", () => {
+  const params = new URLSearchParams("q=geometry&sort=notAField&dir=desc");
+  assert.deepEqual(parseExerciseSorting(params), {
+    orderBy: null,
+    order: "asc",
+  });
+
+  writeExerciseSorting(params, "createdAt", "asc");
+  assert.equal(params.toString(), "q=geometry&sort=createdAt");
+  assert.deepEqual(parseExerciseSorting(params), {
+    orderBy: "createdAt",
+    order: "asc",
+  });
+
+  writeExerciseSorting(params, "createdAt", "desc");
+  assert.equal(params.toString(), "q=geometry&sort=createdAt&dir=desc");
+});

--- a/tests/reportDateParams.test.ts
+++ b/tests/reportDateParams.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  formatLocalDate,
+  getDefaultReportDateRange,
+  parseLocalDate,
+  parseReportDateRange,
+  writeReportDateRange,
+} from "../src/pages/Reporting/reportDateParams.ts";
+
+const now = new Date(2026, 7, 8, 15, 30);
+
+test("report dates round-trip through query parameters", () => {
+  const params = new URLSearchParams("section=users");
+  const range = {
+    startDate: new Date(2026, 5, 1),
+    endDate: new Date(2026, 6, 31),
+  };
+
+  writeReportDateRange(params, range, now);
+
+  assert.equal(
+    params.toString(),
+    "section=users&from=2026-06-01&to=2026-07-31",
+  );
+  assert.deepEqual(parseReportDateRange(params, now), range);
+});
+
+test("empty parameters use the rolling one-month default", () => {
+  const range = parseReportDateRange(new URLSearchParams(), now);
+  assert.equal(formatLocalDate(range.startDate), "2026-07-08");
+  assert.equal(formatLocalDate(range.endDate), "2026-08-08");
+
+  const params = new URLSearchParams();
+  writeReportDateRange(params, getDefaultReportDateRange(now), now);
+  assert.equal(params.toString(), "");
+});
+
+test("invalid dates and reversed ranges safely fall back to defaults", () => {
+  assert.equal(parseLocalDate("2026-02-30"), null);
+  assert.equal(parseLocalDate("08/08/2026"), null);
+
+  const range = parseReportDateRange(
+    new URLSearchParams("from=2026-09-01&to=2026-08-01"),
+    now,
+  );
+  assert.equal(formatLocalDate(range.startDate), "2026-07-08");
+  assert.equal(formatLocalDate(range.endDate), "2026-08-08");
+});


### PR DESCRIPTION
Persist search/check filters, sorting, and report date ranges in query parameters so refreshes and browser navigation preserve page state.

Closes #35

Checks: `yarn test`, TypeScript, focused ESLint, and `yarn build`.